### PR TITLE
Fix PyYAML security vulnerability

### DIFF
--- a/gen.py
+++ b/gen.py
@@ -27,7 +27,7 @@ smkdir("meta")
 if short: smkdir("meta/short")
 if full: smkdir("meta/full")
 
-for section in yaml.load(get_contents("config/index")):
+for section in yaml.load(get_contents("config/index"), Loader=yaml.FullLoader):
     if short: slr = slr + section_heading(section)
     if full:
         flr = flr + section_heading(section)
@@ -52,7 +52,7 @@ for section in yaml.load(get_contents("config/index")):
             except: print("%d\tchanged" % rule)
         else: print("%d\tprocessing" % rule)
 
-        ldata = yaml.load(data)
+        ldata = yaml.load(data, Loader=yaml.FullLoader)
         
         prop_list[str(rule)] = [
             get_hash(data),

--- a/rulekeep/history.py
+++ b/rulekeep/history.py
@@ -43,7 +43,8 @@ def proposal_data(num, log=False):
     except KeyError:
         if log: print("\tp%s\treading from file " % num)
         cache[num] = yaml.load(
-            get_contents("proposals/" + num)
+            get_contents("proposals/" + num),
+            Loader=yaml.FullLoader
         )
         if log: print("\t\tread")
     return cache[num]

--- a/rules/2034
+++ b/rules/2034
@@ -2,8 +2,8 @@ id: 2034
 name: Vote Protection and Cutoff for Challenges
 power: 3
 text: |
-  A public message purporting to resolve an Agoran decision
-  is a self-ratifying attestation that
+  A public message purporting to resolve an Agoran decision is a
+  self-ratifying attestation that
 
   1. such a decision existed,
 

--- a/rules/2143
+++ b/rules/2143
@@ -36,9 +36,9 @@ text: |
   on the World Wide Web, and they SHOULD publish the address of this
   copy along with their published reports.
 
-  A player CAN, by announcement, petition a specified officer to take
-  a specified action; the officer SHALL publicly respond to the
-  petition in a timely fashion.
+  A player CAN, by announcement, petition a specified officer to
+  take a specified action; the officer SHALL publicly respond to
+  the petition in a timely fashion.
 history:
 - change:
     type: enactment

--- a/rules/2160
+++ b/rules/2160
@@ -3,8 +3,8 @@ name: Deputisation
 power: 3
 text: |
   A player acting as emself (the deputy) CAN perform an action
-  ordinarily reserved for an office-holder as if e held the
-  office if
+  ordinarily reserved for an office-holder as if e held the office
+  if
 
   1. the rules require the holder of that office, by virtue of
      holding that office, to perform the action (this requirement is

--- a/rules/2478
+++ b/rules/2478
@@ -5,7 +5,8 @@ text: |
   A player CAN by announcement, but subject to the provisions of
   this rule, Point eir Finger at a person (the perp) who plays the
   game; the announcement has to explicitly name the perp and cite a
-  specific rule and an alleged violation of that rule by that person.
+  specific rule and an alleged violation of that rule by that
+  person.
 
   When a player Points a Finger, the investigator SHALL investigate
   the allegation and CAN, and in a timely fashion SHALL, conclude

--- a/rules/2602
+++ b/rules/2602
@@ -7,10 +7,10 @@ text: |
   Glitter is not specified.
 
   Each time a player is awarded a type of Glitter, the Tailor CAN
-  once by announcement, and SHALL in an officially timely
-  fashion, grant the player N+1 coins, where N is the number of
-  players who did not own the corresponding type of Ribbon at the
-  time of the award.
+  once by announcement, and SHALL in an officially timely fashion,
+  grant the player N+1 coins, where N is the number of players who
+  did not own the corresponding type of Ribbon at the time of the
+  award.
 history:
 - change:
     type: enactment


### PR DESCRIPTION
This is something I ought to have done a good while ago. PyYAML always complains that using `yaml.load()` without `Loader=` is unsafe because it leads to potentially running arbitrary code. This should not be a problem in the case of this repository, but it is wise to make code secure anyway.

I also fixed a few spacing issues (>72 line widths, putting words in line when there is space) that were bugging me a little bit.

I'm submitting a pull request because I'm not the Rulekeepor. I think this might send emails to everyone. If you do not wish to see my maintenance PRs, I would suggest unsubscribing from this repository's PR feed.