### PR TITLE
Actually use bootstrap's features

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,29 +2,6 @@
 <html>
 <head>
     <title>{{ page.title}} | {{site.name}}</title>
-    <style>
-
-    html {
-        color: #333;
-        line-height: 1.5rem;
-    }
-    
-    body .container {
-        margin-top: 5px;
-    }
-    
-    body .content {
-        margin-top: 60px;
-        width: 750px;
-        margin-left: auto;
-        margin-right: auto;
-    }
-    
-    body .container {
-        width: 750px;
-    }
-    
-    </style>
     <script src="https://code.jquery.com/jquery-3.2.1.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=" crossorigin="anonymous"></script>
     <!-- Latest compiled and minified CSS -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
@@ -36,7 +13,7 @@
 
     {% include Header/header.html %}
     
-    <div class="content">
+    <div class="container" style="margin-top: 70px">
     {{ content }}
     </div>
  

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,6 +2,29 @@
 <html>
 <head>
     <title>{{ page.title}} | {{site.name}}</title>
+    <style>
+
+    html {
+        color: #333;
+        line-height: 1.5rem;
+    }
+    
+    body .container {
+        margin-top: 5px;
+    }
+    
+    body .content {
+        margin-top: 60px;
+        width: 750px;
+        margin-left: auto;
+        margin-right: auto;
+    }
+    
+    body .container {
+        width: 750px;
+    }
+    
+    </style>
     <script src="https://code.jquery.com/jquery-3.2.1.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=" crossorigin="anonymous"></script>
     <!-- Latest compiled and minified CSS -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
@@ -13,7 +36,7 @@
 
     {% include Header/header.html %}
     
-    <div class="container" style="margin-top: 70px">
+    <div class="content">
     {{ content }}
     </div>
  

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,6 +2,9 @@
 <html>
 <head>
     <title>{{ page.title}} | {{site.name}}</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    
     <script src="https://code.jquery.com/jquery-3.2.1.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=" crossorigin="anonymous"></script>
     <!-- Latest compiled and minified CSS -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">


### PR DESCRIPTION
The CSS code found in `_layout/default.html` was my personal lightweight code to make the website responsive. When nch added the Bootstrap code, it messed with mine a lot. I've gotten rid of almost all the custom CSS, making it reliant on Bootstrap. It looks more manageable on all the platforms I've tried. 